### PR TITLE
No NEON for Travis iOS builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,6 +28,7 @@ dist:
 env:
   global:
     - TEST=--test
+    - FWD=
 
 matrix:
 
@@ -97,10 +98,9 @@ matrix:
         osx_image: xcode9.4
         env: TOOLCHAIN=osx-10-13-cxx14 CONFIG=Debug
 
-#     Tries to use arm asm.
-#      - os: osx
-#        osx_image: xcode9.4
-#        env: TOOLCHAIN=ios-nocodesign-11-4-dep-9-3 CONFIG=Debug
+      - os: osx
+        osx_image: xcode9.4
+        env: TOOLCHAIN=ios-nocodesign-11-4-dep-9-3 CONFIG=Debug TEST= FWD="--fwd PNG_HARDWARE_OPTIMIZATIONS=NO"
       # }
 
       # Release {
@@ -112,10 +112,9 @@ matrix:
         osx_image: xcode9.4
         env: TOOLCHAIN=osx-10-13-cxx14 CONFIG=Release
 
-#     Tries to use arm asm.
-#      - os: osx
-#        osx_image: xcode9.4
-#        env: TOOLCHAIN=ios-nocodesign-11-4-dep-9-3 CONFIG=Release
+      - os: osx
+        osx_image: xcode9.4
+        env: TOOLCHAIN=ios-nocodesign-11-4-dep-9-3 CONFIG=Release TEST= FWD="--fwd PNG_HARDWARE_OPTIMIZATIONS=NO"
       # }
 
     # }
@@ -163,7 +162,7 @@ install:
 
 script:
   # Allow 20 minutes for the long silent last test.
-  - travis_wait polly.py --toolchain ${TOOLCHAIN} --config ${CONFIG} --verbose ${TEST}
+  - travis_wait polly.py --toolchain ${TOOLCHAIN} --config ${CONFIG} --verbose ${TEST} ${FWD}
 
 # https://docs.travis-ci.com/user/customizing-the-build/#Whitelisting-or-blacklisting-branches
 # Exclude branch 'pkg.template'. Nothing to build there.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -71,12 +71,7 @@ if(PNG_HARDWARE_OPTIMIZATIONS)
 if(CMAKE_SYSTEM_PROCESSOR MATCHES "^arm" OR
     CMAKE_SYSTEM_PROCESSOR MATCHES "^aarch64")
   set(PNG_ARM_NEON_POSSIBLE_VALUES check on off)
-  if(IOS)
-    set(neon_default "off")
-  else()
-    set(neon_default "check")
-  endif()
-  set(PNG_ARM_NEON "${neon_default}" CACHE STRING "Enable ARM NEON optimizations:
+  set(PNG_ARM_NEON "check" CACHE STRING "Enable ARM NEON optimizations:
      check: (default) use internal checking code;
      off: disable the optimizations;
      on: turn on unconditionally.")
@@ -177,29 +172,11 @@ endif()
 
 else(PNG_HARDWARE_OPTIMIZATIONS)
 
-# set definitions and sources for arm
-if(CMAKE_SYSTEM_PROCESSOR MATCHES "^arm" OR
-   CMAKE_SYSTEM_PROCESSOR MATCHES "^aarch64")
-  add_definitions(-DPNG_ARM_NEON_OPT=0)
-endif()
-
-# set definitions and sources for powerpc
-if(CMAKE_SYSTEM_PROCESSOR MATCHES "^powerpc*" OR
-   CMAKE_SYSTEM_PROCESSOR MATCHES "^ppc64*")
-  add_definitions(-DPNG_POWERPC_VSX_OPT=0)
-endif()
-
-# set definitions and sources for intel
-if(CMAKE_SYSTEM_PROCESSOR MATCHES "^i?86" OR
-   CMAKE_SYSTEM_PROCESSOR MATCHES "^x86_64*")
-  add_definitions(-DPNG_INTEL_SSE_OPT=0)
-endif()
-
-# set definitions and sources for MIPS
-if(CMAKE_SYSTEM_PROCESSOR MATCHES "mipsel*" OR
-   CMAKE_SYSTEM_PROCESSOR MATCHES "mips64el*")
-  add_definitions(-DPNG_MIPS_MSA_OPT=0)
-endif()
+# set definitions and sources for arm, powerpc, intel and MIPS
+add_definitions(-DPNG_ARM_NEON_OPT=0)
+add_definitions(-DPNG_POWERPC_VSX_OPT=0)
+add_definitions(-DPNG_INTEL_SSE_OPT=0)
+add_definitions(-DPNG_MIPS_MSA_OPT=0)
 
 endif(PNG_HARDWARE_OPTIMIZATIONS)
 


### PR DESCRIPTION
The CMake script only adds the NEON sources when `CMAKE_SYSTEM_PROCESSOR` contains `arm` but the iOS builds are multi-arch, so `CMAKE_SYSTEM_PROCESSOR` is empty. During compilation, the arm target is detected using defines and attempts to call the NEON functions. As such, linking fails.

This PR disables hardware optimizations for the iOS Travis builds to avoid the scenario above.